### PR TITLE
IO-284: Fix issue with logging tables and code styles

### DIFF
--- a/civicrm_proximity.admin.inc
+++ b/civicrm_proximity.admin.inc
@@ -9,14 +9,14 @@
  * Menu callback for admin settings.
  */
 function civicrm_proximity_admin_configure() {
-  $form['civicrm_proximity_geoloc_apikey'] = array(
+  $form['civicrm_proximity_geoloc_apikey'] = [
     '#type' => 'textfield',
     '#title' => t('Google Maps API Key'),
-    '#description' => t('The Google Maps API, which include geolocation services, requires either a Google API Key. Obtain a Google Maps API key <a href="!url">here</a>.', array(
+    '#description' => t('The Google Maps API, which include geolocation services, requires either a Google API Key. Obtain a Google Maps API key <a href="!url">here</a>.', [
       '!url' => url('https://developers.google.com/maps/documentation/javascript/get-api-key'),
-    )),
+    ]),
     '#default_value' => variable_get('civicrm_proximity_geoloc_apikey', ''),
     '#required' => TRUE,
-  );
+  ];
   return system_settings_form($form);
 }

--- a/civicrm_proximity.install
+++ b/civicrm_proximity.install
@@ -14,14 +14,14 @@ function civicrm_proximity_schema_alter(&$schema) {
   }
 
   if (isset($schema['civicrm_address'])) {
-    $schema['civicrm_address']['fields']['distance'] = array(
-      'type'        => 'float',
-      'size'        => 'big',
-      'not null'    => TRUE,
-      'unsigned'    => TRUE,
-      'default'     => 0,
+    $schema['civicrm_address']['fields']['distance'] = [
+      'type' => 'float',
+      'size' => 'big',
+      'not null' => TRUE,
+      'unsigned' => TRUE,
+      'default' => 0,
       'description' => 'Field added by civicrm_proximity.',
-    );
+    ];
   }
 
   return $schema;
@@ -35,12 +35,12 @@ function civicrm_proximity_install() {
     return;
   }
 
-  $schema['civicrm_address'] = array();
+  $schema['civicrm_address'] = [];
   civicrm_proximity_schema_alter($schema);
 
   foreach ($schema['civicrm_address']['fields'] as $field => $spec) {
     if (db_field_exists('civicrm_address', $field)) {
-      watchdog('system', 'Module install: Attempt to recreate field: "%field", when it already exists.', array('%field' => $field), WATCHDOG_WARNING);
+      watchdog('system', 'Module install: Attempt to recreate field: "%field", when it already exists.', ['%field' => $field], WATCHDOG_WARNING);
     }
     else {
       db_add_field('civicrm_address', $field, $spec);
@@ -58,7 +58,7 @@ function civicrm_proximity_install() {
  * Implements hook_uninstall().
  */
 function civicrm_proximity_uninstall() {
-  $schema['civicrm_address'] = array();
+  $schema['civicrm_address'] = [];
   civicrm_proximity_schema_alter($schema);
 
   foreach ($schema['civicrm_address']['fields'] as $field => $specs) {

--- a/civicrm_proximity.install
+++ b/civicrm_proximity.install
@@ -44,6 +44,12 @@ function civicrm_proximity_install() {
     }
     else {
       db_add_field('civicrm_address', $field, $spec);
+
+      if (CRM_Core_Config::singleton()->logging) {
+        // This fixes the logging tables, because of this new field added.
+        $schema = new CRM_Logging_Schema();
+        $schema->fixSchemaDifferences();
+      }
     }
   }
 }

--- a/civicrm_proximity.module
+++ b/civicrm_proximity.module
@@ -47,7 +47,7 @@ function civicrm_proximity_menu() {
 }
 
 /**
- * Implements hook_measurement_units()
+ * Implements hook_measurement_units().
  *
  * Expose available units of measurement. To perform conversion
  * we must implement, for each unit, its respective:
@@ -119,12 +119,13 @@ function civicrm_proximity_measurement_units_convert_back($unit, $value) {
 /**
  * Query Google geocoding web service.
  *
- * @param $address
+ * @param string $address
  *   Address or location name.
  *
- * @return Geocoder response.
+ * @return array
+ *   Geocoder's response.
  */
-function civicrm_proximity_geocode($address) {
+function civicrm_proximity_geocode(string $address) {
   $locs = $args = array();
 
   $args['address'] = str_replace(' ', '+', $address);

--- a/civicrm_proximity.module
+++ b/civicrm_proximity.module
@@ -134,7 +134,7 @@ function civicrm_proximity_geocode(string $address) {
   $args['language'] = $language->language;
   $args['oe'] = 'utf-8';
   $args['sensor'] = 'false';
-  $args['key'] = $key = trim(variable_get('civicrm_proximity_geoloc_apikey', ''));
+  $args['key'] = trim(variable_get('civicrm_proximity_geoloc_apikey', ''));
 
   $query = http_build_query($args, '', '&');
 

--- a/civicrm_proximity.module
+++ b/civicrm_proximity.module
@@ -23,10 +23,10 @@ function civicrm_proximity_init() {
  * Implements hook_views_api().
  */
 function civicrm_proximity_views_api() {
-  return array(
-    'api'  => 3,
+  return [
+    'api' => 3,
     'path' => drupal_get_path('module', 'civicrm_proximity'),
-  );
+  ];
 }
 
 /**
@@ -54,18 +54,18 @@ function civicrm_proximity_menu() {
  * hook_measurement_units_convert(<UNIT>, <VALUE>).
  */
 function civicrm_proximity_measurement_units() {
-  return array(
-    'km' => array(
-      'long'  => t('Kilometers'),
+  return [
+    'km' => [
+      'long' => t('Kilometers'),
       'short' => t('Km'),
       'const' => 0.62137,
-    ),
-    'miles' => array(
-      'long'  => t('Miles'),
+    ],
+    'miles' => [
+      'long' => t('Miles'),
       'short' => t('Mi'),
       'const' => 1.609344,
-    ),
-  );
+    ],
+  ];
 }
 
 /**
@@ -79,7 +79,7 @@ function civicrm_proximity_get_available_units() {
  * Gets available unit of measurement as select options.
  */
 function civicrm_proximity_get_available_units_for_select() {
-  $units = array();
+  $units = [];
 
   foreach (civicrm_proximity_measurement_units() as $unit => $info) {
     $units[$unit] = $info['long'];
@@ -126,7 +126,7 @@ function civicrm_proximity_measurement_units_convert_back($unit, $value) {
  *   Geocoder's response.
  */
 function civicrm_proximity_geocode(string $address) {
-  $locs = $args = array();
+  $locs = $args = [];
 
   $args['address'] = str_replace(' ', '+', $address);
 
@@ -153,7 +153,7 @@ function civicrm_proximity_geocode(string $address) {
 
   if ($response->status == CIVICRM_PROXIMITY_GOOGLE_STATUS_OK) {
     foreach ($response->results as $result) {
-      $loc = $components = array();
+      $loc = $components = [];
 
       foreach ($result->address_components as $component) {
         $key = $component->types[0];

--- a/civicrm_proximity.views.inc
+++ b/civicrm_proximity.views.inc
@@ -9,22 +9,22 @@
  * Implements hook_views_data_alter().
  */
 function civicrm_proximity_views_data_alter(&$data) {
-  $data['civicrm_address']['circle'] = array(
-    'title'  => t('Circular search'),
-    'help'   => t('Uses the great-circle distance formula to return locations within a circular area.'),
-    'filter' => array(
+  $data['civicrm_address']['circle'] = [
+    'title' => t('Circular search'),
+    'help' => t('Uses the great-circle distance formula to return locations within a circular area.'),
+    'filter' => [
       'handler' => 'civicrm_proximity_handler_filter_circle',
-    ),
-  );
+    ],
+  ];
 
-  $data['civicrm_address']['distance'] = array(
+  $data['civicrm_address']['distance'] = [
     'title' => t('Distance'),
-    'help'  => t('Search radius for addresses in results'),
-    'field' => array(
+    'help' => t('Search radius for addresses in results'),
+    'field' => [
       'handler' => 'civicrm_proximity_handler_field',
       'click sortable' => TRUE,
-    ),
-  );
+    ],
+  ];
 
   return $data;
 }

--- a/phpcs-drupal-ruleset.xml
+++ b/phpcs-drupal-ruleset.xml
@@ -9,5 +9,8 @@
   <!-- Drupal sniffs -->
   <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
     <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/>
+    <exclude name="Drupal.NamingConventions.ValidClassName"/>
+    <exclude name="Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps"/>
+    <exclude name="Drupal.NamingConventions.ValidVariableName.LowerCamelName"/>
   </rule>
 </ruleset>

--- a/views/civicrm_proximity_handler_field.inc
+++ b/views/civicrm_proximity_handler_field.inc
@@ -94,8 +94,6 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
 
       if (!empty($this->options['set_precision'])) {
         $p = $this->options['precision'];
-        $d = $this->options['decimal'];
-        $s = $this->options['separator'];
 
         $value = round($distance, $p);
       }

--- a/views/civicrm_proximity_handler_field.inc
+++ b/views/civicrm_proximity_handler_field.inc
@@ -11,10 +11,10 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
   public function option_definition() {
     $options = parent::option_definition();
 
-    $options['location_provider'] = array('default' => '');
-    $options['set_precision']     = array('default' => TRUE);
-    $options['precision']         = array('default' => 1);
-    $options['hide_empty']        = array('default' => TRUE);
+    $options['location_provider'] = ['default' => ''];
+    $options['set_precision'] = ['default' => TRUE];
+    $options['precision'] = ['default' => 1];
+    $options['hide_empty'] = ['default' => TRUE];
 
     $this->definition['float'] = TRUE;
 
@@ -30,7 +30,7 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
     parent::options_form($form, $form_state);
 
     if ($handlers = $this->view->display_handler->get_handlers('filter')) {
-      $options = array();
+      $options = [];
 
       foreach ($handlers as $name => $handler) {
         $handler_def = $handler->definition['handler'];
@@ -43,11 +43,11 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
         }
       }
 
-      $form['location_provider'] = array(
-        '#title'   => t('Search from'),
-        '#type'    => 'select',
+      $form['location_provider'] = [
+        '#title' => t('Search from'),
+        '#type' => 'select',
         '#options' => $options,
-      );
+      ];
     }
   }
 
@@ -55,9 +55,9 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
    * Overwrite views_handler_field_numeric::query().
    */
   public function query() {
-    $lp      = $this->options['location_provider'];
+    $lp = $this->options['location_provider'];
     $handler = $this->view->display_handler->get_handler('filter', $lp);
-    $alias   = $handler->table_alias();
+    $alias = $handler->table_alias();
 
     if ($handler
     && $handler->value['location']
@@ -84,7 +84,7 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
       // Get the unit of measurement.
       $exp_unit = $handler->value[$handler->options['expose']['unit']];
       $hid_unit = $handler->value['unit'];
-      $unit     = $handler->options['exposed'] ? $exp_unit : $hid_unit;
+      $unit = $handler->options['exposed'] ? $exp_unit : $hid_unit;
       $distance = $value->distance;
 
       // Convert back to kilometers.
@@ -112,9 +112,9 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
       }
 
       $units = civicrm_proximity_get_available_units();
-      $pre   = $this->options['prefix'];
+      $pre = $this->options['prefix'];
       $short = $units[$unit]['short'];
-      $suf   = $this->options['suffix'];
+      $suf = $this->options['suffix'];
 
       return $this->sanitize_value($pre . $value . ' ' . $short . ' ' . $suf);
     }

--- a/views/civicrm_proximity_handler_field.inc
+++ b/views/civicrm_proximity_handler_field.inc
@@ -22,8 +22,9 @@ class civicrm_proximity_handler_field extends views_handler_field_numeric {
   }
 
   /**
-   * Basic options for all sort criteria
-   * Overwrite views_handler_field_numeric::options_form().
+   * Basic options for all sort criteria.
+   *
+   * @see views_handler_field_numeric::options_form()
    */
   public function options_form(&$form, &$form_state) {
     parent::options_form($form, $form_state);

--- a/views/civicrm_proximity_handler_filter.inc
+++ b/views/civicrm_proximity_handler_filter.inc
@@ -48,19 +48,19 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
     $output = check_plain($options[$this->operator]);
 
     if (in_array($this->operator, $this->operator_values(2))) {
-      $output .= ' ' . t('@min and @max @unit from @location', array(
-        '@min'      => $this->value['min'],
-        '@max'      => $this->value['max'],
-        '@unit'     => $this->value['unit'],
+      $output .= ' ' . t('@min and @max @unit from @location', [
+        '@min' => $this->value['min'],
+        '@max' => $this->value['max'],
+        '@unit' => $this->value['unit'],
         '@location' => $this->value['location'],
-      ));
+      ]);
     }
     elseif (in_array($this->operator, $this->operator_values(1))) {
-      $output .= ' ' . t('@value @unit from @location', array(
-        '@value'    => $this->value['value'],
-        '@unit'     => $this->value['unit'],
+      $output .= ' ' . t('@value @unit from @location', [
+        '@value' => $this->value['value'],
+        '@unit' => $this->value['unit'],
         '@location' => $this->value['location'],
-      ));
+      ]);
     }
 
     return $output;
@@ -71,16 +71,16 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
    */
   public function option_definition() {
     $options = parent::option_definition();
-    $options['operator'] = array('default' => '<');
+    $options['operator'] = ['default' => '<'];
 
     $unit = variable_get('civicrm_proximity_unit', CIVICRM_PROXIMITY_DEFAULT_UNIT);
 
-    $options['value']['contains']['unit']     = array('default' => $unit);
-    $options['value']['contains']['location'] = array('default' => '');
+    $options['value']['contains']['unit'] = ['default' => $unit];
+    $options['value']['contains']['location'] = ['default' => ''];
 
-    $options['expose']['contains']['use_unit'] = array('default' => FALSE);
-    $options['expose']['contains']['unit']     = array('default' => 'unit');
-    $options['expose']['contains']['location'] = array('default' => 'location');
+    $options['expose']['contains']['use_unit'] = ['default' => FALSE];
+    $options['expose']['contains']['unit'] = ['default' => 'unit'];
+    $options['expose']['contains']['location'] = ['default' => 'location'];
 
     return $options;
   }
@@ -120,33 +120,33 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
 
     drupal_add_css(drupal_get_path('module', 'civicrm_proximity') . '/civicrm_proximity.css');
 
-    $form['value']['operator'] = array(
-      '#attributes'    => array(
-        'class' => array('civicrm-proximity civicrm-proximity-operator'),
-      ),
-    );
+    $form['value']['operator'] = [
+      '#attributes' => [
+        'class' => ['civicrm-proximity civicrm-proximity-operator'],
+      ],
+    ];
 
-    $form['value']['unit'] = array(
-      '#title'         => t('Unit of measurement'),
-      '#type'          => 'select',
-      '#options'       => civicrm_proximity_get_available_units_for_select(),
+    $form['value']['unit'] = [
+      '#title' => t('Unit of measurement'),
+      '#type' => 'select',
+      '#options' => civicrm_proximity_get_available_units_for_select(),
       '#default_value' => $this->options['value']['unit'],
-      '#description'   => t('Select unit of measurement.'),
-      '#attributes'    => array(
-        'class' => array('civicrm-proximity civicrm-proximity-unit'),
-      ),
-    );
+      '#description' => t('Select unit of measurement.'),
+      '#attributes' => [
+        'class' => ['civicrm-proximity civicrm-proximity-unit'],
+      ],
+    ];
 
-    $form['value']['location'] = array(
-      '#title'         => t('from Location'),
-      '#type'          => 'textfield',
-      '#size'          => 20,
+    $form['value']['location'] = [
+      '#title' => t('from Location'),
+      '#type' => 'textfield',
+      '#size' => 20,
       '#default_value' => $this->options['value']['location'],
-      '#description'   => t('Where to start the search. This can be an address, city or postcode. If searching in London, try "London N1" instead of "N1".'),
-      '#attributes'    => array(
-        'class' => array('civicrm-proximity civicrm-proximity-location'),
-      ),
-    );
+      '#description' => t('Where to start the search. This can be an address, city or postcode. If searching in London, try "London N1" instead of "N1".'),
+      '#attributes' => [
+        'class' => ['civicrm-proximity civicrm-proximity-location'],
+      ],
+    ];
   }
 
   /**
@@ -158,7 +158,7 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
     parent::operator_form($form, $form_state);
 
     // At the end of the day proximity search is a rough estimation.
-    $unset = array('<=', '=', '!=', '>=');
+    $unset = ['<=', '=', '!=', '>='];
     $this->unset_attributes($form['operator']['#options'], $unset);
   }
 
@@ -196,7 +196,7 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
         unset($form[$this->options['expose']['identifier']]['max']);
       }
 
-      $this->unset_attributes($form[$operator], array('#options'));
+      $this->unset_attributes($form[$operator], ['#options']);
     }
 
     // When exposed pull location and unit out of value form item.
@@ -210,7 +210,7 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
         $this->clean_exposed_filter_item($identifier[$name]);
       }
       else {
-        $this->unset_attributes($identifier, array('unit'));
+        $this->unset_attributes($identifier, ['unit']);
       }
 
       // Expose location form, if necessary.
@@ -220,11 +220,11 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
         $location = $this->rename_exposed_filter_item($form, $location);
         $this->clean_exposed_filter_item($identifier[$location]);
 
-        $identifier[$location]['#weight']       = 100;
+        $identifier[$location]['#weight'] = 100;
         $identifier[$location]['#field_prefix'] = t('from');
       }
       else {
-        $this->unset_attributes($identifier, array($location));
+        $this->unset_attributes($identifier, [$location]);
 
         if ($this->filter_item_is_exposed('unit')) {
           $suffix = $this->get_suffix();
@@ -252,7 +252,7 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
           $field_prefix = '';
         }
 
-        $identifier['value']['#size']         = 3;
+        $identifier['value']['#size'] = 3;
         $identifier['value']['#field_prefix'] = $field_prefix;
         $identifier['value']['#field_suffix'] = $this->get_suffix();
 
@@ -260,10 +260,10 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
 
       // Add meaningful prefix/suffix to min max.
       if (isset($identifier['min']) && isset($filter['max'])) {
-        $identifier['min']['#size']         = 3;
+        $identifier['min']['#size'] = 3;
         $identifier['min']['#field_prefix'] = $force_operator ? $operators[$this->options['operator']] : '';
 
-        $identifier['max']['#size']         = 3;
+        $identifier['max']['#size'] = 3;
         $identifier['max']['#field_prefix'] = t('and');
         $identifier['max']['#field_suffix'] = $this->get_suffix();
 
@@ -285,7 +285,7 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
     $operator   = $this->options['expose']['operator'];
     $location   = $this->options['expose']['location'];
 
-    foreach (array('value', 'min', 'max') as $field) {
+    foreach (['value', 'min', 'max'] as $field) {
       if (isset($form_state['values'][$identifier][$field])) {
         $form_state['values'][$identifier][$field] = str_replace(',', '.', $form_state['values'][$identifier][$field]);
       }
@@ -295,7 +295,7 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
     $op     = $values[$operator];
 
     // Validate "value", "min" and "max".
-    $fields = ($op == 'between') ? array('min', 'max') : array('value');
+    $fields = ($op == 'between') ? ['min', 'max'] : ['value'];
 
     foreach ($fields as $key => $field) {
       if ($values[$identifier][$field]) {
@@ -342,15 +342,11 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
    */
   public function secure_input() {
     $this->value['value'] = isset($this->value['value']) ? $this->value['value'] : $this->options['value']['value'];
-    $this->value['min']   = isset($this->value['min']) ? $this->value['min'] : $this->options['value']['min'];
-    $this->value['max']   = isset($this->value['max']) ? $this->value['max'] : $this->options['value']['max'];
+    $this->value['min'] = isset($this->value['min']) ? $this->value['min'] : $this->options['value']['min'];
+    $this->value['max'] = isset($this->value['max']) ? $this->value['max'] : $this->options['value']['max'];
 
     $this->value['location'] = isset($this->value[$this->options['expose']['location']]) ? $this->value[$this->options['expose']['location']] : $this->options['value']['location'];
-    $this->value['unit']     = isset($this->value[$this->options['expose']['unit']]) ? $this->value[$this->options['expose']['unit']] : $this->options['value']['unit'];
-
-    $this->value['value'] = $this->value['value'];
-    $this->value['min']   = $this->value['min'];
-    $this->value['max']   = $this->value['max'];
+    $this->value['unit'] = isset($this->value[$this->options['expose']['unit']]) ? $this->value[$this->options['expose']['unit']] : $this->options['value']['unit'];
   }
 
   /**
@@ -393,20 +389,20 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
    *   Title of the option.
    */
   public function expose_option_form(array &$form, string $name, string $title) {
-    $form['expose'][$name] = array(
-      '#type'          => 'checkbox',
-      '#title'         => t('Unlock @title', array('@title' => $title)),
+    $form['expose'][$name] = [
+      '#type' => 'checkbox',
+      '#title' => t('Unlock @title', ['@title' => $title]),
       '#default_value' => $this->options['expose'][$name],
-      '#description'   => t('When checked, this filter will be exposed to the user'),
-    );
+      '#description' => t('When checked, this filter will be exposed to the user'),
+    ];
 
-    $form['expose'][$name] = array(
-      '#type'          => 'textfield',
+    $form['expose'][$name] = [
+      '#type' => 'textfield',
       '#default_value' => $this->options['expose'][$name],
-      '#title'         => t('@title identifier', array('@title' => $title)),
-      '#size'          => 40,
-      '#description'   => t('This will appear in the URL after the ? to identify this filter.'),
-    );
+      '#title' => t('@title identifier', ['@title' => $title]),
+      '#size' => 40,
+      '#description' => t('This will appear in the URL after the ? to identify this filter.'),
+    ];
   }
 
   /**
@@ -421,12 +417,12 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
    *   Value of the filter.
    */
   public function rename_exposed_filter_item(array &$form, string $name) {
-    $value      = $this->options['expose'][$name];
+    $value = $this->options['expose'][$name];
     $identifier = $this->options['expose']['identifier'];
 
     if ($value != $name) {
       $form[$identifier][$value] = $form[$identifier][$name];
-      $this->unset_attributes($form[$identifier], array($name));
+      $this->unset_attributes($form[$identifier], [$name]);
     }
 
     return $value;

--- a/views/civicrm_proximity_handler_filter.inc
+++ b/views/civicrm_proximity_handler_filter.inc
@@ -7,6 +7,8 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
 
   /**
    * Exposed filter options.
+   *
+   * @var bool
    */
   public $no_single = FALSE;
 
@@ -27,14 +29,15 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
   /**
    * Process operator.
    */
-  public function op_process($op = 'simple', $field) {
+  public function op_process($op = 'simple', $field = NULL) {
     $this->secure_input();
     $this->process_location_proximity();
   }
 
   /**
-   * Display the filter on the administrative summary
-   * Overwrite of views_handler_filter_numeric::admin_summary().
+   * Display the filter on the administrative summary.
+   *
+   * @see views_handler_filter_numeric::admin_summary()
    */
   public function admin_summary() {
     if (!empty($this->options['exposed'])) {
@@ -84,7 +87,8 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
 
   /**
    * Provide default options for exposed filters.
-   * Overwrite of views_handler_filter::expose_options().
+   *
+   * @see views_handler_filter::expose_options()
    */
   public function expose_options() {
     parent::expose_options();
@@ -96,7 +100,8 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
 
   /**
    * Handle the "left" side of the exposed options form.
-   * Overwrite of views_handler_filter::expose_form().
+   *
+   * @see views_handler_filter::expose_form()
    */
   public function expose_form(&$form, &$form_state) {
     parent::expose_form($form, $form_state);
@@ -106,8 +111,9 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
   }
 
   /**
-   * Provide a simple textfield for equality
-   * Overwrite of views_handler_filter_numeric::value_form().
+   * Provide a simple textfield for equality.
+   *
+   * @see views_handler_filter_numeric::value_form()
    */
   public function value_form(&$form, &$form_state) {
     parent::value_form($form, $form_state);
@@ -145,7 +151,8 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
 
   /**
    * Provide a form for setting the operator.
-   * Overwrite of views_handler_filter::operator_form().
+   *
+   * @see views_handler_filter::operator_form()
    */
   public function operator_form(&$form, &$form_state) {
     parent::operator_form($form, $form_state);
@@ -156,8 +163,9 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
   }
 
   /**
-   * Render our chunk of the exposed filter form when selecting
-   * Overwrite of views_handler_filter::exposed_form().
+   * Render our chunk of the exposed filter form when selecting.
+   *
+   * @see views_handler_filter::exposed_form()
    */
   public function exposed_form(&$form, &$form_state) {
     if (empty($this->options['exposed'])) {
@@ -259,8 +267,8 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
         $identifier['max']['#field_prefix'] = t('and');
         $identifier['max']['#field_suffix'] = $this->get_suffix();
 
-        $this->unset_attributes($identifier['max'], array('#title', '#default_value'));
-        $this->unset_attributes($identifier['min'], array('#default_value'));
+        $this->unset_attributes($identifier['max'], ['#title', '#default_value']);
+        $this->unset_attributes($identifier['min'], ['#default_value']);
       }
     }
   }
@@ -348,12 +356,12 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
   /**
    * Unset the attributes.
    *
-   * @param $item
-   *   Item information
-   * @param $attributes
+   * @param array $item
+   *   Item information.
+   * @param array $attributes
    *   Attributes to be unsetted.
    */
-  public function unset_attributes(&$item, $attributes) {
+  public function unset_attributes(array &$item, array $attributes) {
     foreach ($attributes as $name) {
       unset($item[$name]);
     }
@@ -362,24 +370,29 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
   /**
    * Clean the exposed filters.
    *
-   * @param $item
+   * @param array $item
    *   Filters to be cleaned.
    */
-  public function clean_exposed_filter_item(&$item) {
-    $this->unset_attributes($item, array('#prefix', '#suffix', '#title', '#description'));
+  public function clean_exposed_filter_item(array &$item) {
+    $this->unset_attributes($item, [
+      '#prefix',
+      '#suffix',
+      '#title',
+      '#description',
+    ]);
   }
 
   /**
    * Expose option in the given form.
    *
-   * @param $form
+   * @param array $form
    *   Form to be modified.
-   * @param $name
+   * @param string $name
    *   Name of the option.
-   * @param $title
+   * @param string $title
    *   Title of the option.
    */
-  public function expose_option_form(&$form, $name, $title) {
+  public function expose_option_form(array &$form, string $name, string $title) {
     $form['expose'][$name] = array(
       '#type'          => 'checkbox',
       '#title'         => t('Unlock @title', array('@title' => $title)),
@@ -399,15 +412,15 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
   /**
    * Rename exposed filter item.
    *
-   * @param $form
+   * @param array $form
    *   Form to be modified.
-   * @param $name
+   * @param string $name
    *   Name of the filter.
    *
    * @return mixed
    *   Value of the filter.
    */
-  public function rename_exposed_filter_item(&$form, $name) {
+  public function rename_exposed_filter_item(array &$form, string $name) {
     $value      = $this->options['expose'][$name];
     $identifier = $this->options['expose']['identifier'];
 
@@ -422,13 +435,13 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
   /**
    * Indicates if the filter is exposed.
    *
-   * @param $name
-   *   Name of the filter
+   * @param string $name
+   *   Name of the filter.
    *
    * @return bool
    *   Returns TRUE if the filter is exposed.
    */
-  public function filter_item_is_exposed($name) {
+  public function filter_item_is_exposed(string $name) {
     return !empty($this->options['expose'][$name]);
   }
 
@@ -444,7 +457,11 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
       $suffix = '@unit ' . $suffix;
     }
 
-    return t($suffix, array('@unit' => $units[$this->options['value']['unit']]['long'], '@location' => $this->options['value']['location']));
+    // phpcs:ignore Drupal.Semantics.FunctionT.NotLiteralString
+    return t($suffix, [
+      '@unit' => $units[$this->options['value']['unit']]['long'],
+      '@location' => $this->options['value']['location'],
+    ]);
   }
 
 }

--- a/views/civicrm_proximity_handler_filter.inc
+++ b/views/civicrm_proximity_handler_filter.inc
@@ -280,10 +280,9 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
     parent::exposed_validate($form, $form_state);
 
     // Sanitize "value", "min" and "max".
-    $operators  = $this->operators();
     $identifier = $this->options['expose']['identifier'];
-    $operator   = $this->options['expose']['operator'];
-    $location   = $this->options['expose']['location'];
+    $operator = $this->options['expose']['operator'];
+    $location = $this->options['expose']['location'];
 
     foreach (['value', 'min', 'max'] as $field) {
       if (isset($form_state['values'][$identifier][$field])) {
@@ -341,12 +340,12 @@ class civicrm_proximity_handler_filter extends views_handler_filter_numeric {
    * Clean the inputs.
    */
   public function secure_input() {
-    $this->value['value'] = isset($this->value['value']) ? $this->value['value'] : $this->options['value']['value'];
-    $this->value['min'] = isset($this->value['min']) ? $this->value['min'] : $this->options['value']['min'];
-    $this->value['max'] = isset($this->value['max']) ? $this->value['max'] : $this->options['value']['max'];
+    $this->value['value'] = $this->value['value'] ?? $this->options['value']['value'];
+    $this->value['min'] = $this->value['min'] ?? $this->options['value']['min'];
+    $this->value['max'] = $this->value['max'] ?? $this->options['value']['max'];
 
-    $this->value['location'] = isset($this->value[$this->options['expose']['location']]) ? $this->value[$this->options['expose']['location']] : $this->options['value']['location'];
-    $this->value['unit'] = isset($this->value[$this->options['expose']['unit']]) ? $this->value[$this->options['expose']['unit']] : $this->options['value']['unit'];
+    $this->value['location'] = $this->value[$this->options['expose']['location']] ?? $this->options['value']['location'];
+    $this->value['unit'] = $this->value[$this->options['expose']['unit']] ?? $this->options['value']['unit'];
   }
 
   /**

--- a/views/civicrm_proximity_handler_filter_circle.inc
+++ b/views/civicrm_proximity_handler_filter_circle.inc
@@ -16,7 +16,7 @@ class civicrm_proximity_handler_filter_circle extends civicrm_proximity_handler_
       $longitude = $this->value['lon'];
       $distance = $this->value['value'];
 
-      $table   = $this->table_alias();
+      $table = $this->table_alias();
       $formula = $this->table_formula($latitude, $longitude, $table);
 
       $this->query->add_field($table, 'distance');
@@ -32,34 +32,34 @@ class civicrm_proximity_handler_filter_circle extends civicrm_proximity_handler_
           $this->query->add_where(
             $group,
             $table . '.geo_code_1',
-            array($lat_lon['lat1'], $lat_lon['lat2']),
+            [$lat_lon['lat1'], $lat_lon['lat2']],
             'BETWEEN'
           );
 
           $this->query->add_where(
             $group,
             $table . '.geo_code_2',
-            array($lat_lon['lon1'], $lat_lon['lon2']),
+            [$lat_lon['lon1'], $lat_lon['lon2']],
             'BETWEEN'
           );
         }
       }
       else {
         if ($this->operator == 'between') {
-          $between = array($this->value['min'], $this->value['max']);
+          $between = [$this->value['min'], $this->value['max']];
           $upper = $this->calculate_coordinates($latitude, $longitude, $this->value['max']);
 
           $this->query->add_where(
             $group,
             $table . '.geo_code_1',
-            array($upper['lat1'], $upper['lat2']),
+            [$upper['lat1'], $upper['lat2']],
             'BETWEEN'
           );
 
           $this->query->add_where(
             $group,
             $table . '.geo_code_2',
-            array($upper['lon1'], $upper['lon2']),
+            [$upper['lon1'], $upper['lon2']],
             'BETWEEN'
           );
 
@@ -100,12 +100,12 @@ class civicrm_proximity_handler_filter_circle extends civicrm_proximity_handler_
    * Returns the table formula.
    */
   public function table_formula($lat, $lon, $table) {
-    $args = array(
+    $args = [
       ':lat1' => $table . '.geo_code_1',
       ':lon1' => $table . '.geo_code_2',
       ':lat2' => $lat,
       ':lon2' => $lon,
-    );
+    ];
 
     $great_circle = strtr(CIVICRM_PROXIMITY_SQL_GREAT_CIRCLE, $args);
 
@@ -137,7 +137,7 @@ class civicrm_proximity_handler_filter_circle extends civicrm_proximity_handler_
    *   The radius of the search circle.
    */
   public function calculate_coordinates($lat, $lon, $dist) {
-    $vals = array();
+    $vals = [];
 
     $vals['lon1'] = $lon - $dist / abs(cos(deg2rad($lat)) * 111);
     $vals['lon2'] = $lon + $dist / abs(cos(deg2rad($lat)) * 111);

--- a/views/civicrm_proximity_handler_filter_circle.inc
+++ b/views/civicrm_proximity_handler_filter_circle.inc
@@ -8,7 +8,7 @@ class civicrm_proximity_handler_filter_circle extends civicrm_proximity_handler_
   /**
    * Process operator.
    */
-  public function op_process($op = 'simple', $field) {
+  public function op_process($op = 'simple', $field = NULL) {
     parent::op_process($op, $field);
 
     if (!is_null($this->value['lat']) && !is_null($this->value['lon'])) {
@@ -129,11 +129,11 @@ class civicrm_proximity_handler_filter_circle extends civicrm_proximity_handler_
   /**
    * Function to calculate the needed coordinates.
    *
-   * @param float $lat:
+   * @param float $lat
    *   The starting point latitude.
-   * @param float $lon:
+   * @param float $lon
    *   The starting point longitude.
-   * @param float $dist:
+   * @param float $dist
    *   The radius of the search circle.
    */
   public function calculate_coordinates($lat, $lon, $dist) {

--- a/views/civicrm_proximity_handler_sort.inc
+++ b/views/civicrm_proximity_handler_sort.inc
@@ -11,7 +11,7 @@ class civicrm_proximity_handler_sort extends views_handler_sort {
   public function option_definition() {
     $options = parent::option_definition();
 
-    $options['location_provider'] = array('default' => '');
+    $options['location_provider'] = ['default' => ''];
     return $options;
   }
 
@@ -20,7 +20,7 @@ class civicrm_proximity_handler_sort extends views_handler_sort {
    */
   public function options_form(&$form, &$form_state) {
     if ($handlers = $this->view->display_handler->get_handlers('filter')) {
-      $options = array();
+      $options = [];
 
       foreach ($handlers as $name => $handler) {
         $definition = $handler->definition['handler'];
@@ -34,11 +34,11 @@ class civicrm_proximity_handler_sort extends views_handler_sort {
         }
       }
 
-      $form['location_provider'] = array(
+      $form['location_provider'] = [
         '#title' => t('Location provider'),
         '#type' => 'select',
         '#options' => $options,
-      );
+      ];
     }
 
     parent::options_form($form, $form_state);


### PR DESCRIPTION
## Overview
This PR solves the problem experienced on CiviCRM installations with logging activated. At the same time, provides some code style fixes and minor refactors.

## Before
After installing the module on a local environment, or any with the logging enabled (which is discouraged in the production), there was an error while saving contact's addresses:
<img width="1621" alt="Screen Shot 2021-09-23 at 23 52 42" src="https://user-images.githubusercontent.com/74304572/134634989-7e8a46af-649b-49b7-843c-b3251a19eb73.png">

On the error logs, we can see that is referring to a non-existent `distance` field. The field exists on the main table, but not on the triggers for logging, that's why the SQL error:
> [debug_info] => UPDATE  `civicrm_address`  SET `contact_id` = 9 , `location_type_id` = 2 , `is_primary` = 1 , `is_billing` = 0 , `street_address` = '83 Baldock Street' , `supplemental_address_1` = NULL , `supplemental_address_2` = NULL , `supplemental_address_3` = NULL , `city` = 'NEWTON-LE-WILLOWS' , `postal_code` = 'WA12 7EZ' , `country_id` = 1226 , `geo_code_1` = 53.452889 , `geo_code_2` = -2.63508 , `manual_geo_code` = 0 , `master_id` = NULL   WHERE (  `civicrm_address`.`id` = 2 )   [nativecode=1054 ** Unknown column 'distance' in 'field list']

## After
The field can be saved correctly, without errors.

## Technical details
- The `fixSchemaDifferences` is called only when the field is added, and if logging is enabled. I was able to reproduce the error many times and see it fixed by applying this. 
- On another side, the code style fixes also include some modifications to the rules, because as was discussed in chat, some are not necessary. The rules excluded are:
```xml
    <exclude name="Drupal.NamingConventions.ValidClassName"/>
    <exclude name="Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps"/>
    <exclude name="Drupal.NamingConventions.ValidVariableName.LowerCamelName"/>
```    
- All the other errors were solved. Also, it was removed the assignation alignment, because is not the way in which we work usually.
- Finally, the old syntax for declaring arrays `array()` was replaced by the new one `[]`.